### PR TITLE
Add data entry overlay

### DIFF
--- a/hcneu/src/components/dataentry/DataEntryForm.tsx
+++ b/hcneu/src/components/dataentry/DataEntryForm.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { saveDataEntry } from '../../lib/dataentry';
+
+export interface EntryFormValues {
+  date: string;
+  symptoms: string;
+  notes: string;
+}
+
+interface Props {
+  onClose: () => void;
+}
+
+const DataEntryForm: React.FC<Props> = ({ onClose }) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<EntryFormValues>({
+    defaultValues: { date: '', symptoms: '', notes: '' },
+  });
+
+  const onSubmit = async (data: EntryFormValues) => {
+    try {
+      await saveDataEntry(data);
+      reset();
+      onClose();
+    } catch (err) {
+      console.error('Failed to save entry', err);
+    }
+  };
+
+  return (
+    <div className="data-entry-overlay" onClick={onClose}>
+      <form
+        className="data-entry-form"
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <h2>Neuer Eintrag</h2>
+
+        <label>
+          Datum
+          <input type="date" {...register('date', { required: 'Datum wählen' })} />
+          {errors.date && <span className="error-message">{errors.date.message}</span>}
+        </label>
+
+        <label>
+          Symptome
+          <input type="text" placeholder="Symptome" {...register('symptoms')} />
+        </label>
+
+        <label>
+          Notizen
+          <textarea placeholder="Notizen" rows={4} {...register('notes')} />
+        </label>
+
+        <div className="actions">
+          <button type="button" onClick={onClose}>Abbrechen</button>
+          <button type="submit">Speichern</button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default DataEntryForm;

--- a/hcneu/src/lib/dataentry.ts
+++ b/hcneu/src/lib/dataentry.ts
@@ -1,0 +1,16 @@
+import { supabase } from './supabase';
+import type { EntryFormValues } from '../components/dataentry/DataEntryForm';
+
+export async function saveDataEntry(values: EntryFormValues) {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) throw new Error('No session');
+
+  const { error } = await supabase.from('entries').insert({
+    user_id: session.user.id,
+    date: values.date,
+    symptoms: values.symptoms,
+    notes: values.notes,
+  });
+
+  if (error) throw error;
+}

--- a/hcneu/src/pages/DashboardPage.tsx
+++ b/hcneu/src/pages/DashboardPage.tsx
@@ -11,11 +11,13 @@ import DashboardHeader from '../components/Dashboard/DashboardHeader';
 import GlowingBackground from '../components/layout/GlowingBackground';
 import HeroSection from '../components/herosection/HeroSection';
 import { content } from '../content/content'; // ✅ use your content
+import DataEntryForm from '../components/dataentry/DataEntryForm';
 
 const DashboardPage: React.FC = () => {
   const navigate = useNavigate();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [showEmailReminder, setShowEmailReminder] = useState(false);
+  const [showEntryForm, setShowEntryForm] = useState(false);
 
   // ✅ Check for email confirmation
   useEffect(() => {
@@ -70,19 +72,19 @@ const DashboardPage: React.FC = () => {
                 title="Du hast innerhalb der letzten Woche Werte für 3 Tage angegeben"
                 subtitle=""
                 status="Positive Entwicklung im letzten Monat"
-                onAdd={() => console.log("Add Stuhlgang")}
+                onAdd={() => setShowEntryForm(true)}
               />
               <OverviewCard
                 label="Symptome"
                 title="Keine Daten"
                 subtitle="Kein auffälligen Ereignisse"
-                onAdd={() => console.log("Add Symptome")}
+                onAdd={() => setShowEntryForm(true)}
               />
               <OverviewCard
                 label="Wohlbefinden"
                 title="Steigend"
                 subtitle="Positive Entwicklung letzte Woche"
-                onAdd={() => console.log("Add Wohlbefinden")}
+                onAdd={() => setShowEntryForm(true)}
               />
             </div>
           </div>
@@ -116,6 +118,9 @@ const DashboardPage: React.FC = () => {
       </div>
 
       <BottomNav />
+      {showEntryForm && (
+        <DataEntryForm onClose={() => setShowEntryForm(false)} />
+      )}
     </div>
   );
 };

--- a/hcneu/src/styles/global.css
+++ b/hcneu/src/styles/global.css
@@ -1,8 +1,44 @@
-/* src/global.css */
+/* src/styles/global.css */
 .tile-base {
-    border-radius: 12px;       /* consistent rounded corners */
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* soft shadow */
-    background-color: #fff;    /* default background */
-    transition: all 0.2s ease-in-out;
-  }
-  
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  background-color: #fff;
+  transition: all 0.2s ease-in-out;
+}
+
+.data-entry-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(6px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+
+.data-entry-form {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 1rem;
+  width: 90%;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.data-entry-form input,
+.data-entry-form textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
+  font: inherit;
+}
+
+.data-entry-form .actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- allow adding metrics via a new overlay form
- support saving entries in Supabase
- style form and overlay globally
- integrate the new form in the dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842e889bc348332a1aa886444d44ba7