### PR TITLE
Add symptom & wellbeing forms

### DIFF
--- a/hcneu/src/components/dataentry/SymptomForm.tsx
+++ b/hcneu/src/components/dataentry/SymptomForm.tsx
@@ -6,41 +6,55 @@ import { useWindowSize } from 'react-use';
 import { saveSymptomEntry } from '../../lib/symptoms';
 
 export interface SymptomFormValues {
-  date: string;
-  severity: number;
   notes: string;
-  shared_with_team: boolean;
+  shared_with_team: string;
+  details: string[];
+  intensity: number;
+  locations: string[];
+  times_of_day: string[];
+  timeframe: string[];
+  symptom_type: string;
 }
 
 interface Props {
   onClose: () => void;
 }
 
-const steps = ['Datum', 'Schwere', 'Notizen', 'Datenschutz'];
+const steps = [
+  'Notizen',
+  'Art',
+  'Intensität',
+  'Lokalisation',
+  'Tageszeit',
+  'Zeitraum',
+  'Typ',
+];
 
 const SymptomForm: React.FC<Props> = ({ onClose }) => {
   const [step, setStep] = useState(0);
-  const [customDate, setCustomDate] = useState('');
   const [showConfetti, setShowConfetti] = useState(false);
   const [showForm, setShowForm] = useState(true);
-  const [dateError, setDateError] = useState('');
   const { width, height } = useWindowSize();
 
   const { register, handleSubmit, reset, setValue, watch } = useForm<SymptomFormValues>({
     defaultValues: {
-      date: '',
-      severity: 0,
       notes: '',
-      shared_with_team: false,
+      shared_with_team: 'false',
+      details: [],
+      intensity: 0,
+      locations: [],
+      times_of_day: [],
+      timeframe: [],
+      symptom_type: 'symptom',
     },
   });
 
-  const today = new Date().toISOString().split('T')[0];
-  const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
-
   const onSubmit = async (data: SymptomFormValues) => {
     try {
-      await saveSymptomEntry(data);
+      await saveSymptomEntry({
+        ...data,
+        shared_with_team: data.shared_with_team === 'true',
+      });
       setShowConfetti(true);
       setShowForm(false);
       setTimeout(() => {
@@ -56,11 +70,6 @@ const SymptomForm: React.FC<Props> = ({ onClose }) => {
   const progress = ((step + 1) / steps.length) * 100;
 
   const handleNextStep = () => {
-    if (step === 0 && !watch('date')) {
-      setDateError('Bitte wähle ein Datum aus.');
-      return;
-    }
-    setDateError('');
     setStep((prev) => prev + 1);
   };
 
@@ -99,76 +108,98 @@ const SymptomForm: React.FC<Props> = ({ onClose }) => {
                   transition={{ duration: 0.3 }}
                 >
                   {step === 0 && (
-                    <div className="date-options">
-                      <button
-                        type="button"
-                        className="input-group"
-                        onClick={() => {
-                          setCustomDate('');
-                          setValue('date', today);
-                        }}
-                      >
-                        Heute
-                      </button>
-                      <button
-                        type="button"
-                        className="input-group"
-                        onClick={() => {
-                          setCustomDate('');
-                          setValue('date', yesterday);
-                        }}
-                      >
-                        Gestern
-                      </button>
-                      <label className="input-group date">
-                        Anderes Datum wählen
-                        <input
-                          type="date"
-                          value={customDate}
-                          onChange={(e) => {
-                            setCustomDate(e.target.value);
-                            setValue('date', e.target.value);
-                          }}
-                        />
+                    <>
+                      <label className="input-group">
+                        <textarea rows={3} placeholder="Notizen (optional)" {...register('notes')} />
                       </label>
-                      {dateError && <p className="form-error">{dateError}</p>}
-                    </div>
+                      <div className="checkbox-list">
+                        <label className="checkbox-row">
+                          <input type="radio" value="false" {...register('shared_with_team')} />
+                          Nur für mich
+                        </label>
+                        <label className="checkbox-row">
+                          <input type="radio" value="true" {...register('shared_with_team')} />
+                          Auch für mein Behandlungsteam
+                        </label>
+                        <p className="disclaimer-text">Taucht in Bericht auf oder nicht</p>
+                      </div>
+                    </>
                   )}
 
                   {step === 1 && (
+                    <div className="checkbox-list">
+                      {['Letzter Eintrag', 'Drückend', 'Pochend', 'Aufgebläht', 'Stechend', 'Ziehend', 'Krampfend'].map((d) => (
+                        <label className="checkbox-row" key={d}>
+                          <input type="checkbox" value={d} {...register('details')} />
+                          {d}
+                        </label>
+                      ))}
+                    </div>
+                  )}
+
+                  {step === 2 && (
                     <div className="counter-wrapper">
                       <button
                         type="button"
                         className="counter-btn"
-                        onClick={() => setValue('severity', Math.max(0, watch('severity') - 1))}
+                        onClick={() => setValue('intensity', Math.max(0, watch('intensity') - 1))}
                       >
                         –
                       </button>
-                      <span className="count-display">{watch('severity')}</span>
+                      <span className="count-display">{watch('intensity')}</span>
                       <button
                         type="button"
                         className="counter-btn"
-                        onClick={() => setValue('severity', watch('severity') + 1)}
+                        onClick={() => setValue('intensity', watch('intensity') + 1)}
                       >
                         +
                       </button>
                     </div>
                   )}
 
-                  {step === 2 && (
-                    <label className="input-group">
-                      <textarea rows={3} placeholder="Notizen (optional)" {...register('notes')} />
-                    </label>
+                  {step === 3 && (
+                    <div className="checkbox-list">
+                      {['Kopf', 'Oberkörper', 'Darm', 'Magen'].map((l) => (
+                        <label className="checkbox-row" key={l}>
+                          <input type="checkbox" value={l} {...register('locations')} />
+                          {l}
+                        </label>
+                      ))}
+                    </div>
                   )}
 
-                  {step === 3 && (
-                    <>
-                      <label className="checkbox-row">
-                        <input type="checkbox" {...register('shared_with_team')} />
-                        Mit Behandlungsteam teilen
-                      </label>
-                      <p className="disclaimer-text">Diese Information erscheint im Arztbericht.</p>
-                    </>
+                  {step === 4 && (
+                    <div className="checkbox-list">
+                      {['Jetzt', 'Ohne Tageszeit', 'Vormittags', 'Mittags', 'Abends'].map((t) => (
+                        <label className="checkbox-row" key={t}>
+                          <input type="checkbox" value={t} {...register('times_of_day')} />
+                          {t}
+                        </label>
+                      ))}
+                    </div>
+                  )}
+
+                  {step === 5 && (
+                    <div className="checkbox-list">
+                      {['Letzter Eintrag', 'Heute', 'Gestern', 'Diese Woche', 'Zeitraum eintragen'].map((tf) => (
+                        <label className="checkbox-row" key={tf}>
+                          <input type="checkbox" value={tf} {...register('timeframe')} />
+                          {tf}
+                        </label>
+                      ))}
+                    </div>
+                  )}
+
+                  {step === 6 && (
+                    <div className="checkbox-list">
+                      {['Letzten Eintrag', 'Ganz klar – Symptom', 'Eindeutig – eine Nebenwirkung', 'Ich bin mir unsicher'].map((ty) => (
+                        <label className="checkbox-row" key={ty}>
+                          <input type="radio" value={ty} {...register('symptom_type')} />
+                          {ty}
+                        </label>
+                      ))}
+                      <p className="disclaimer-text">Artikel Hilfe: Wie kann ich unterscheiden?</p>
+                    </div>
                   )}
                 </motion.div>
               </AnimatePresence>

--- a/hcneu/src/components/dataentry/SymptomForm.tsx
+++ b/hcneu/src/components/dataentry/SymptomForm.tsx
@@ -1,0 +1,217 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { motion, AnimatePresence } from 'framer-motion';
+import Confetti from 'react-confetti';
+import { useWindowSize } from 'react-use';
+import { saveSymptomEntry } from '../../lib/symptoms';
+
+export interface SymptomFormValues {
+  date: string;
+  severity: number;
+  notes: string;
+  shared_with_team: boolean;
+}
+
+interface Props {
+  onClose: () => void;
+}
+
+const steps = ['Datum', 'Schwere', 'Notizen', 'Datenschutz'];
+
+const SymptomForm: React.FC<Props> = ({ onClose }) => {
+  const [step, setStep] = useState(0);
+  const [customDate, setCustomDate] = useState('');
+  const [showConfetti, setShowConfetti] = useState(false);
+  const [showForm, setShowForm] = useState(true);
+  const [dateError, setDateError] = useState('');
+  const { width, height } = useWindowSize();
+
+  const { register, handleSubmit, reset, setValue, watch } = useForm<SymptomFormValues>({
+    defaultValues: {
+      date: '',
+      severity: 0,
+      notes: '',
+      shared_with_team: false,
+    },
+  });
+
+  const today = new Date().toISOString().split('T')[0];
+  const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+
+  const onSubmit = async (data: SymptomFormValues) => {
+    try {
+      await saveSymptomEntry(data);
+      setShowConfetti(true);
+      setShowForm(false);
+      setTimeout(() => {
+        setShowConfetti(false);
+        reset();
+        onClose();
+      }, 1800);
+    } catch (err) {
+      console.error('Fehler beim Speichern', err);
+    }
+  };
+
+  const progress = ((step + 1) / steps.length) * 100;
+
+  const handleNextStep = () => {
+    if (step === 0 && !watch('date')) {
+      setDateError('Bitte wähle ein Datum aus.');
+      return;
+    }
+    setDateError('');
+    setStep((prev) => prev + 1);
+  };
+
+  return (
+    <AnimatePresence>
+      {showForm && (
+        <motion.div
+          className="data-entry-overlay"
+          onClick={() => {
+            setShowForm(false);
+            setTimeout(onClose, 300);
+          }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.form
+            className="data-entry-form tile-base"
+            onClick={(e) => e.stopPropagation()}
+            onSubmit={handleSubmit(onSubmit)}
+            initial={{ scale: 0.95, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            <div className="form-inner">
+              <h2 className="form-title">{steps[step]}</h2>
+
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={step}
+                  className="form-content"
+                  initial={{ opacity: 0, x: 30 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -30 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  {step === 0 && (
+                    <div className="date-options">
+                      <button
+                        type="button"
+                        className="input-group"
+                        onClick={() => {
+                          setCustomDate('');
+                          setValue('date', today);
+                        }}
+                      >
+                        Heute
+                      </button>
+                      <button
+                        type="button"
+                        className="input-group"
+                        onClick={() => {
+                          setCustomDate('');
+                          setValue('date', yesterday);
+                        }}
+                      >
+                        Gestern
+                      </button>
+                      <label className="input-group date">
+                        Anderes Datum wählen
+                        <input
+                          type="date"
+                          value={customDate}
+                          onChange={(e) => {
+                            setCustomDate(e.target.value);
+                            setValue('date', e.target.value);
+                          }}
+                        />
+                      </label>
+                      {dateError && <p className="form-error">{dateError}</p>}
+                    </div>
+                  )}
+
+                  {step === 1 && (
+                    <div className="counter-wrapper">
+                      <button
+                        type="button"
+                        className="counter-btn"
+                        onClick={() => setValue('severity', Math.max(0, watch('severity') - 1))}
+                      >
+                        –
+                      </button>
+                      <span className="count-display">{watch('severity')}</span>
+                      <button
+                        type="button"
+                        className="counter-btn"
+                        onClick={() => setValue('severity', watch('severity') + 1)}
+                      >
+                        +
+                      </button>
+                    </div>
+                  )}
+
+                  {step === 2 && (
+                    <label className="input-group">
+                      <textarea rows={3} placeholder="Notizen (optional)" {...register('notes')} />
+                    </label>
+                  )}
+
+                  {step === 3 && (
+                    <>
+                      <label className="checkbox-row">
+                        <input type="checkbox" {...register('shared_with_team')} />
+                        Mit Behandlungsteam teilen
+                      </label>
+                      <p className="disclaimer-text">Diese Information erscheint im Arztbericht.</p>
+                    </>
+                  )}
+                </motion.div>
+              </AnimatePresence>
+
+              <div className="form-navigation">
+                <button
+                  type="button"
+                  onClick={() => setStep(step - 1)}
+                  disabled={step === 0}
+                  className="btn back-btn"
+                >
+                  Zurück
+                </button>
+
+                {step < steps.length - 1 ? (
+                  <button type="button" className="btn next-btn" onClick={handleNextStep}>
+                    Weiter
+                  </button>
+                ) : (
+                  <button type="submit" className="btn next-btn">
+                    Speichern
+                  </button>
+                )}
+              </div>
+            </div>
+          </motion.form>
+          <div className="progress-bar-container">
+            <div className="progress-bar-fill" style={{ width: `${progress}%` }} />
+          </div>
+        </motion.div>
+      )}
+      {showConfetti && (
+        <Confetti
+          width={width}
+          height={height}
+          recycle={false}
+          numberOfPieces={350}
+          gravity={0.5}
+          tweenDuration={300}
+        />
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default SymptomForm;

--- a/hcneu/src/components/dataentry/WellbeingForm.tsx
+++ b/hcneu/src/components/dataentry/WellbeingForm.tsx
@@ -1,0 +1,217 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { motion, AnimatePresence } from 'framer-motion';
+import Confetti from 'react-confetti';
+import { useWindowSize } from 'react-use';
+import { saveWellbeingEntry } from '../../lib/wellbeing';
+
+export interface WellbeingFormValues {
+  date: string;
+  rating: number;
+  notes: string;
+  shared_with_team: boolean;
+}
+
+interface Props {
+  onClose: () => void;
+}
+
+const steps = ['Datum', 'Bewertung', 'Notizen', 'Datenschutz'];
+
+const WellbeingForm: React.FC<Props> = ({ onClose }) => {
+  const [step, setStep] = useState(0);
+  const [customDate, setCustomDate] = useState('');
+  const [showConfetti, setShowConfetti] = useState(false);
+  const [showForm, setShowForm] = useState(true);
+  const [dateError, setDateError] = useState('');
+  const { width, height } = useWindowSize();
+
+  const { register, handleSubmit, reset, setValue, watch } = useForm<WellbeingFormValues>({
+    defaultValues: {
+      date: '',
+      rating: 0,
+      notes: '',
+      shared_with_team: false,
+    },
+  });
+
+  const today = new Date().toISOString().split('T')[0];
+  const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+
+  const onSubmit = async (data: WellbeingFormValues) => {
+    try {
+      await saveWellbeingEntry(data);
+      setShowConfetti(true);
+      setShowForm(false);
+      setTimeout(() => {
+        setShowConfetti(false);
+        reset();
+        onClose();
+      }, 1800);
+    } catch (err) {
+      console.error('Fehler beim Speichern', err);
+    }
+  };
+
+  const progress = ((step + 1) / steps.length) * 100;
+
+  const handleNextStep = () => {
+    if (step === 0 && !watch('date')) {
+      setDateError('Bitte wähle ein Datum aus.');
+      return;
+    }
+    setDateError('');
+    setStep((prev) => prev + 1);
+  };
+
+  return (
+    <AnimatePresence>
+      {showForm && (
+        <motion.div
+          className="data-entry-overlay"
+          onClick={() => {
+            setShowForm(false);
+            setTimeout(onClose, 300);
+          }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.form
+            className="data-entry-form tile-base"
+            onClick={(e) => e.stopPropagation()}
+            onSubmit={handleSubmit(onSubmit)}
+            initial={{ scale: 0.95, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            <div className="form-inner">
+              <h2 className="form-title">{steps[step]}</h2>
+
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={step}
+                  className="form-content"
+                  initial={{ opacity: 0, x: 30 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -30 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  {step === 0 && (
+                    <div className="date-options">
+                      <button
+                        type="button"
+                        className="input-group"
+                        onClick={() => {
+                          setCustomDate('');
+                          setValue('date', today);
+                        }}
+                      >
+                        Heute
+                      </button>
+                      <button
+                        type="button"
+                        className="input-group"
+                        onClick={() => {
+                          setCustomDate('');
+                          setValue('date', yesterday);
+                        }}
+                      >
+                        Gestern
+                      </button>
+                      <label className="input-group date">
+                        Anderes Datum wählen
+                        <input
+                          type="date"
+                          value={customDate}
+                          onChange={(e) => {
+                            setCustomDate(e.target.value);
+                            setValue('date', e.target.value);
+                          }}
+                        />
+                      </label>
+                      {dateError && <p className="form-error">{dateError}</p>}
+                    </div>
+                  )}
+
+                  {step === 1 && (
+                    <div className="counter-wrapper">
+                      <button
+                        type="button"
+                        className="counter-btn"
+                        onClick={() => setValue('rating', Math.max(0, watch('rating') - 1))}
+                      >
+                        –
+                      </button>
+                      <span className="count-display">{watch('rating')}</span>
+                      <button
+                        type="button"
+                        className="counter-btn"
+                        onClick={() => setValue('rating', watch('rating') + 1)}
+                      >
+                        +
+                      </button>
+                    </div>
+                  )}
+
+                  {step === 2 && (
+                    <label className="input-group">
+                      <textarea rows={3} placeholder="Notizen (optional)" {...register('notes')} />
+                    </label>
+                  )}
+
+                  {step === 3 && (
+                    <>
+                      <label className="checkbox-row">
+                        <input type="checkbox" {...register('shared_with_team')} />
+                        Mit Behandlungsteam teilen
+                      </label>
+                      <p className="disclaimer-text">Diese Information erscheint im Arztbericht.</p>
+                    </>
+                  )}
+                </motion.div>
+              </AnimatePresence>
+
+              <div className="form-navigation">
+                <button
+                  type="button"
+                  onClick={() => setStep(step - 1)}
+                  disabled={step === 0}
+                  className="btn back-btn"
+                >
+                  Zurück
+                </button>
+
+                {step < steps.length - 1 ? (
+                  <button type="button" className="btn next-btn" onClick={handleNextStep}>
+                    Weiter
+                  </button>
+                ) : (
+                  <button type="submit" className="btn next-btn">
+                    Speichern
+                  </button>
+                )}
+              </div>
+            </div>
+          </motion.form>
+          <div className="progress-bar-container">
+            <div className="progress-bar-fill" style={{ width: `${progress}%` }} />
+          </div>
+        </motion.div>
+      )}
+      {showConfetti && (
+        <Confetti
+          width={width}
+          height={height}
+          recycle={false}
+          numberOfPieces={350}
+          gravity={0.5}
+          tweenDuration={300}
+        />
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default WellbeingForm;

--- a/hcneu/src/lib/symptoms.ts
+++ b/hcneu/src/lib/symptoms.ts
@@ -1,0 +1,41 @@
+import { supabase } from './supabase';
+import type { SymptomFormValues } from '../components/dataentry/SymptomForm';
+
+export async function saveSymptomEntry(values: SymptomFormValues) {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) throw new Error('No session');
+
+  const user_id = session.user.id;
+
+  const { data: existing, error: fetchError } = await supabase
+    .from('symptoms')
+    .select('id')
+    .eq('user_id', user_id)
+    .eq('date', values.date)
+    .maybeSingle();
+
+  if (fetchError) throw fetchError;
+
+  const payload = {
+    user_id,
+    date: values.date,
+    severity: values.severity,
+    notes: values.notes,
+    shared_with_team: values.shared_with_team,
+  };
+
+  let result;
+
+  if (existing) {
+    result = await supabase
+      .from('symptoms')
+      .update(payload)
+      .eq('id', existing.id);
+  } else {
+    result = await supabase
+      .from('symptoms')
+      .insert(payload);
+  }
+
+  if (result.error) throw result.error;
+}

--- a/hcneu/src/lib/symptoms.ts
+++ b/hcneu/src/lib/symptoms.ts
@@ -7,35 +7,17 @@ export async function saveSymptomEntry(values: SymptomFormValues) {
 
   const user_id = session.user.id;
 
-  const { data: existing, error: fetchError } = await supabase
-    .from('symptoms')
-    .select('id')
-    .eq('user_id', user_id)
-    .eq('date', values.date)
-    .maybeSingle();
-
-  if (fetchError) throw fetchError;
-
-  const payload = {
+  const result = await supabase.from('symptom_entries').insert({
     user_id,
-    date: values.date,
-    severity: values.severity,
     notes: values.notes,
     shared_with_team: values.shared_with_team,
-  };
-
-  let result;
-
-  if (existing) {
-    result = await supabase
-      .from('symptoms')
-      .update(payload)
-      .eq('id', existing.id);
-  } else {
-    result = await supabase
-      .from('symptoms')
-      .insert(payload);
-  }
+    details: values.details,
+    intensity: values.intensity,
+    locations: values.locations,
+    times_of_day: values.times_of_day,
+    timeframe: values.timeframe,
+    symptom_type: values.symptom_type,
+  });
 
   if (result.error) throw result.error;
 }

--- a/hcneu/src/lib/wellbeing.ts
+++ b/hcneu/src/lib/wellbeing.ts
@@ -1,0 +1,41 @@
+import { supabase } from './supabase';
+import type { WellbeingFormValues } from '../components/dataentry/WellbeingForm';
+
+export async function saveWellbeingEntry(values: WellbeingFormValues) {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) throw new Error('No session');
+
+  const user_id = session.user.id;
+
+  const { data: existing, error: fetchError } = await supabase
+    .from('wellbeing')
+    .select('id')
+    .eq('user_id', user_id)
+    .eq('date', values.date)
+    .maybeSingle();
+
+  if (fetchError) throw fetchError;
+
+  const payload = {
+    user_id,
+    date: values.date,
+    rating: values.rating,
+    notes: values.notes,
+    shared_with_team: values.shared_with_team,
+  };
+
+  let result;
+
+  if (existing) {
+    result = await supabase
+      .from('wellbeing')
+      .update(payload)
+      .eq('id', existing.id);
+  } else {
+    result = await supabase
+      .from('wellbeing')
+      .insert(payload);
+  }
+
+  if (result.error) throw result.error;
+}

--- a/hcneu/src/pages/DashboardPage.tsx
+++ b/hcneu/src/pages/DashboardPage.tsx
@@ -12,6 +12,8 @@ import GlowingBackground from '../components/layout/GlowingBackground';
 import HeroSection from '../components/herosection/HeroSection';
 import { content } from '../content/content';
 import DataEntryForm from '../components/dataentry/DataEntryForm';
+import SymptomForm from '../components/dataentry/SymptomForm';
+import WellbeingForm from '../components/dataentry/WellbeingForm';
 
 const DashboardPage: React.FC = () => {
   const navigate = useNavigate();
@@ -117,9 +119,15 @@ const DashboardPage: React.FC = () => {
 
       <BottomNav />
 
-      {/* ✅ Only show DataEntryForm for “stuhlfrequenz” */}
+      {/* Open overlay forms based on active section */}
       {activeSection === 'stuhlfrequenz' && (
         <DataEntryForm onClose={() => setActiveSection(null)} />
+      )}
+      {activeSection === 'symptome' && (
+        <SymptomForm onClose={() => setActiveSection(null)} />
+      )}
+      {activeSection === 'wohlbefinden' && (
+        <WellbeingForm onClose={() => setActiveSection(null)} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- create forms for symptoms and wellbeing data entry
- add supabase helpers for new tables
- open corresponding forms from Dashboard based on tile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68469ac15ca48332968164e2679a30b9