### PR TITLE
Display stool frequency entries on DataPage

### DIFF
--- a/hcneu/src/lib/stoolFrequency.ts
+++ b/hcneu/src/lib/stoolFrequency.ts
@@ -1,0 +1,25 @@
+import { supabase } from './supabase';
+
+export interface StoolFrequencyEntry {
+  id: number;
+  date: string;
+  times_of_day: string[];
+  count: number;
+  properties: string[];
+  notes: string | null;
+  shared_with_team: boolean;
+}
+
+export async function fetchStoolFrequency(): Promise<StoolFrequencyEntry[]> {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) throw new Error('No session');
+
+  const { data, error } = await supabase
+    .from('stool_frequency')
+    .select('id, date, times_of_day, count, properties, notes, shared_with_team')
+    .eq('user_id', session.user.id)
+    .order('date', { ascending: false });
+
+  if (error) throw error;
+  return (data as StoolFrequencyEntry[]) || [];
+}

--- a/hcneu/src/pages/DataPage.tsx
+++ b/hcneu/src/pages/DataPage.tsx
@@ -1,14 +1,23 @@
 // src/pages/DataPage.tsx
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import BottomNav from '../components/layout/BottomNav';
 import DashboardHeader from '../components/Dashboard/DashboardHeader';
 import GlowingBackground from '../components/layout/GlowingBackground';
 import './DataPage.css'; // Newly split styles
 import Tile from '../components/layout/Tile';
+import '../components/widgets/TableWidget.css';
+import { fetchStoolFrequency, type StoolFrequencyEntry } from '../lib/stoolFrequency';
 
 const DataPage: React.FC = () => {
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [entries, setEntries] = useState<StoolFrequencyEntry[]>([]);
+
+  useEffect(() => {
+    fetchStoolFrequency()
+      .then(setEntries)
+      .catch((err) => console.error('Fetch error', err));
+  }, []);
 
   return (
     <div className="data-page-wrapper">
@@ -32,6 +41,34 @@ const DataPage: React.FC = () => {
           <h2>Gesundheitsdaten Übersicht</h2>
           <p>Ein Platzhalter für Diagramme, Tabellen und Statistiken über deine bisherigen Einträge.</p>
         </motion.section>
+      </div>
+
+      <div className="data-content">
+        <Tile className="Tile">
+          <h2>Stuhlfrequenz</h2>
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Datum</th>
+                <th>Anzahl</th>
+                <th>Tageszeiten</th>
+                <th>Eigenschaften</th>
+                <th>Notizen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((e) => (
+                <tr key={e.id}>
+                  <td>{e.date}</td>
+                  <td>{e.count}</td>
+                  <td>{e.times_of_day.join(', ')}</td>
+                  <td>{e.properties.join(', ')}</td>
+                  <td>{e.notes}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Tile>
       </div>
 
 


### PR DESCRIPTION
## Summary
- create `fetchStoolFrequency` helper for Supabase
- load stool frequency entries in `DataPage`
- render entries in a simple table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846a16f706c8332bc9103782b3a26dc