### PR TITLE
Add SymptomForm with boolean sharing field

### DIFF
--- a/hcneu/src/components/dataentry/SymptomForm.tsx
+++ b/hcneu/src/components/dataentry/SymptomForm.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { saveSymptomEntry } from '../../lib/symptoms';
+
+export interface SymptomFormValues {
+  date: string;
+  symptoms: string[];
+  notes: string;
+  shared_with_team: boolean;
+}
+
+interface Props {
+  onClose: () => void;
+}
+
+const SymptomForm: React.FC<Props> = ({ onClose }) => {
+  const { register, handleSubmit } = useForm<SymptomFormValues>({
+    defaultValues: {
+      date: '',
+      symptoms: [],
+      notes: '',
+      shared_with_team: false,
+    },
+  });
+
+  const onSubmit = async (data: SymptomFormValues) => {
+    try {
+      await saveSymptomEntry(data);
+      onClose();
+    } catch (err) {
+      console.error('Fehler beim Speichern', err);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <label>
+        Datum
+        <input type="date" {...register('date')} />
+      </label>
+      <label>
+        Symptome
+        <input type="text" {...register('symptoms')} />
+      </label>
+      <label>
+        Notizen
+        <textarea rows={3} {...register('notes')} />
+      </label>
+      <div>
+        <label>
+          <input
+            type="radio"
+            value="true"
+            {...register('shared_with_team', {
+              setValueAs: (v) => v === 'true',
+            })}
+          />
+          Mit Team teilen
+        </label>
+        <label>
+          <input
+            type="radio"
+            value="false"
+            {...register('shared_with_team', {
+              setValueAs: (v) => v === 'true',
+            })}
+          />
+          Privat
+        </label>
+      </div>
+      <button type="submit">Speichern</button>
+    </form>
+  );
+};
+
+export default SymptomForm;

--- a/hcneu/src/lib/symptoms.ts
+++ b/hcneu/src/lib/symptoms.ts
@@ -1,0 +1,21 @@
+import { supabase } from './supabase';
+import type { SymptomFormValues } from '../components/dataentry/SymptomForm';
+
+export async function saveSymptomEntry(values: SymptomFormValues) {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) throw new Error('No session');
+
+  const user_id = session.user.id;
+
+  const { error } = await supabase
+    .from('symptoms')
+    .insert({
+      user_id,
+      date: values.date,
+      symptoms: values.symptoms,
+      notes: values.notes,
+      shared_with_team: values.shared_with_team,
+    });
+
+  if (error) throw error;
+}


### PR DESCRIPTION
## Summary
- create `SymptomForm` component for symptom entry
- add `saveSymptomEntry` util for storing symptom information

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846aceb443c83328c95b16939665275