### PR TITLE
Add form util helpers

### DIFF
--- a/hcneu/src/components/dataentry/DataEntryForm.tsx
+++ b/hcneu/src/components/dataentry/DataEntryForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { booleanCheckbox } from '../../lib/formUtils';
 import { motion, AnimatePresence } from 'framer-motion';
 import Confetti from 'react-confetti';
 import { useWindowSize } from 'react-use';
@@ -200,7 +201,10 @@ const DataEntryForm: React.FC<Props> = ({ onClose }) => {
                   {step === 4 && (
                     <>
                       <label className="checkbox-row">
-                        <input type="checkbox" {...register('shared_with_team')} />
+                        <input
+                          type="checkbox"
+                          {...register('shared_with_team', booleanCheckbox())}
+                        />
                         Mit Behandlungsteam teilen
                       </label>
                       <p className="disclaimer-text">Diese Information erscheint im Arztbericht.</p>

--- a/hcneu/src/lib/formUtils.ts
+++ b/hcneu/src/lib/formUtils.ts
@@ -1,0 +1,30 @@
+// src/lib/formUtils.ts
+import type { RegisterOptions } from 'react-hook-form';
+
+// Convert radio string values like "true"/"false" to boolean
+export function booleanRadio<T>(): RegisterOptions<T> {
+  return {
+    setValueAs: (v: unknown) => {
+      if (typeof v === 'boolean') return v;
+      if (v === 'true' || v === '1') return true;
+      return false;
+    },
+  } as RegisterOptions<T>;
+}
+
+// Parse checkbox values to boolean
+export function booleanCheckbox<T>(): RegisterOptions<T> {
+  return {
+    setValueAs: (v: unknown) => Boolean(v),
+  } as RegisterOptions<T>;
+}
+
+// Parse numeric input strings to numbers
+export function numberValue<T>(): RegisterOptions<T> {
+  return {
+    setValueAs: (v: unknown) => {
+      if (v === '' || v === null || v === undefined) return undefined;
+      return Number(v);
+    },
+  } as RegisterOptions<T>;
+}


### PR DESCRIPTION
## Summary
- add `formUtils.ts` with helper functions for React Hook Form
- use `booleanCheckbox` helper in `DataEntryForm`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846aced244083328752996fb2766471