### PR TITLE
Fix form utils generics

### DIFF
--- a/hcneu/src/components/dataentry/DataEntryForm.tsx
+++ b/hcneu/src/components/dataentry/DataEntryForm.tsx
@@ -200,7 +200,10 @@ const DataEntryForm: React.FC<Props> = ({ onClose }) => {
                   {step === 4 && (
                     <>
                       <label className="checkbox-row">
-                        <input type="checkbox" {...register('shared_with_team')} />
+                        <input
+                          type="checkbox"
+                          {...register('shared_with_team', { valueAsBoolean: true })}
+                        />
                         Mit Behandlungsteam teilen
                       </label>
                       <p className="disclaimer-text">Diese Information erscheint im Arztbericht.</p>

--- a/hcneu/src/lib/formUtils.ts
+++ b/hcneu/src/lib/formUtils.ts
@@ -1,0 +1,19 @@
+import type { FieldErrors, FieldValues, Path, RegisterOptions, UseFormRegister } from 'react-hook-form';
+
+export function registerField<T extends FieldValues>(
+  register: UseFormRegister<T>,
+  name: Path<T>,
+  options?: RegisterOptions<T>
+) {
+  return register(name, options);
+}
+
+export function hasError<T extends FieldValues>(errors: FieldErrors<T>, name: Path<T>) {
+  return Boolean(errors[name]);
+}
+
+export function getErrorMessage<T extends FieldValues>(errors: FieldErrors<T>, name: Path<T>) {
+  const fieldError = errors[name];
+  if (!fieldError) return undefined;
+  return fieldError.message as string | undefined;
+}


### PR DESCRIPTION
## Summary
- introduce utility helpers for react-hook-form
- ensure shared_with_team checkbox parses as boolean

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'babel__core')*

------
https://chatgpt.com/codex/tasks/task_e_6846afb20348833282409adac7083b72